### PR TITLE
[Mailbox] Remove the argument 'progress'

### DIFF
--- a/include/husky-base/mailbox_eventloop.h
+++ b/include/husky-base/mailbox_eventloop.h
@@ -15,13 +15,14 @@
 #pragma once
 
 #include <functional>
-#include <map>
 #include <thread>
+#include <unordered_map>
 
 #include "zmq.hpp"
 
 #include "husky-base/bin_stream.h"
 #include "husky-base/mailbox_adress_book.h"
+#include "husky-base/mailbox_types.h"
 #include "husky-base/shard.h"
 
 namespace husky {
@@ -29,26 +30,18 @@ namespace base {
 
 class MailboxEventLoop {
  public:
-  typedef std::function<void(int local_shard_id, int progress, BinStream*)> RecvAvailableHandlerType;
-  typedef std::function<void(int progress)> RecvCompleteHandlerType;
-  typedef std::function<void(Shard shard, int channel_id, int progress, BinStream*)> SendHandlerType;
-  typedef std::function<void(int channel_id, int progress)> SendCompleteHandlerType;
-
   explicit MailboxEventLoop(zmq::context_t* zmq_context);
   ~MailboxEventLoop();
 
   // There following two methods are not thread-safe, since we assume that they are set up at the very beginning. If
   // they need to be changed later, we need to provide thread-safe ways
-  void OnSend(SendHandlerType handler);
-  void OnSendComplete(SendCompleteHandlerType handler);
+  void OnSend(MailboxSendHandlerType handler);
 
  protected:
   std::unique_ptr<std::thread> thread_;
   zmq::context_t* zmq_context_;
-  std::map<int, RecvAvailableHandlerType> recv_available_handlers_;
-  std::map<int, RecvCompleteHandlerType> recv_complete_handlers_;
-  SendHandlerType send_handler_;
-  SendCompleteHandlerType send_complete_handler_;
+  std::unordered_map<int, MailboxRecvHandlerType> recv_handlers_;
+  MailboxSendHandlerType send_handler_;
 };
 
 }  // namespace base

--- a/include/husky-base/mailbox_sender.h
+++ b/include/husky-base/mailbox_sender.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
+#include <unordered_map>
 
 #include "zmq.hpp"
 
@@ -30,15 +30,13 @@ class MailboxSender {
  public:
   MailboxSender(const MailboxAddressBook& addr_book, zmq::context_t* zmq_context);
 
-  // This takes over the ownership of bin_stream
-  void Send(Shard shard, int channel_id, int progress, BinStream* bin_stream);
-
-  void SendComplete(int channel_id, int progress);
+  // This takes over the ownership of the payload
+  void Send(Shard shard, int channel_id, BinStream* payload);
 
  protected:
   MailboxAddressBook addr_book_;
   zmq::context_t* zmq_context_;
-  std::map<int, std::shared_ptr<zmq::socket_t>> senders_;
+  std::unordered_map<int, std::shared_ptr<zmq::socket_t>> senders_;
 };
 
 }  // namespace base

--- a/include/husky-base/mailbox_types.h
+++ b/include/husky-base/mailbox_types.h
@@ -14,15 +14,19 @@
 
 #pragma once
 
-// Mailbox event types
-const int MAILBOX_EVENT_RECV_COMM = 1;
-const int MAILBOX_EVENT_RECV_COMM_COMPLETE = 2;
-const int MAILBOX_EVENT_SET_RECV_COMM_HANDLER = 3;
-const int MAILBOX_EVENT_SET_RECV_COMM_COMPLETE_HANDLER = 4;
-const int MAILBOX_EVENT_SEND_COMM = 5;
-const int MAILBOX_EVENT_SEND_COMM_COMPLETE = 6;
-const int MAILBOX_EVENT_SHUTDOWN = 7;
+#include <functional>
 
-// Mailbox communication types
-const int MAILBOX_COMM = 8;
-const int MAILBOX_COMM_COMPLETE = 9;
+#include "husky-base/shard.h"
+
+namespace husky {
+namespace base {
+
+// Mailbox event types
+enum MailboxEventType : int32_t { RecvComm = 1, SetRecvHandler = 2, SendComm = 3, Shutdown = 4 };
+
+// Typedefs for send/recv handler
+typedef std::function<void(Shard shard, int channel_id, BinStream* payload)> MailboxSendHandlerType;
+typedef std::function<void(int local_shard_id, BinStream* payload)> MailboxRecvHandlerType;
+
+}  // namespace base
+}  // namespace husky

--- a/src/mailbox_eventloop.cc
+++ b/src/mailbox_eventloop.cc
@@ -14,7 +14,6 @@
 
 #include "husky-base/mailbox_eventloop.h"
 
-#include "husky-base/mailbox_constants.h"
 #include "husky-base/zmq_helpers.h"
 
 namespace husky {
@@ -28,50 +27,28 @@ MailboxEventLoop::MailboxEventLoop(zmq::context_t* zmq_context) : zmq_context_(z
     while (!shutdown) {
       int type = zmq_recv_int32(&event_loop_socket);
       switch (type) {
-      case MAILBOX_EVENT_RECV_COMM: {
+      case MailboxEventType::RecvComm: {
         int local_shard_id = zmq_recv_int32(&event_loop_socket);
         int channel_id = zmq_recv_int32(&event_loop_socket);
-        int progress = zmq_recv_int32(&event_loop_socket);
         BinStream* bin_stream = reinterpret_cast<BinStream*>(zmq_recv_int64(&event_loop_socket));
-        recv_available_handlers_.at(channel_id)(local_shard_id, progress, bin_stream);
+        recv_handlers_.at(channel_id)(local_shard_id, bin_stream);
         break;
       }
-      case MAILBOX_EVENT_RECV_COMM_COMPLETE: {
-        int channel_id = zmq_recv_int32(&event_loop_socket);
-        int progress = zmq_recv_int32(&event_loop_socket);
-        recv_complete_handlers_.at(channel_id)(progress);
-        break;
-      }
-      case MAILBOX_EVENT_SEND_COMM: {
+      case MailboxEventType::SendComm: {
         int process_id = zmq_recv_int32(&event_loop_socket);
         int local_shard_id = zmq_recv_int32(&event_loop_socket);
         int channel_id = zmq_recv_int32(&event_loop_socket);
-        int progress = zmq_recv_int32(&event_loop_socket);
-        BinStream* bin_stream = reinterpret_cast<BinStream*>(zmq_recv_int64(&event_loop_socket));
-        send_handler_({process_id, local_shard_id}, channel_id, progress, bin_stream);
+        BinStream* payload = reinterpret_cast<BinStream*>(zmq_recv_int64(&event_loop_socket));
+        send_handler_({process_id, local_shard_id}, channel_id, payload);
         break;
       }
-      case MAILBOX_EVENT_SEND_COMM_COMPLETE: {
+      case MailboxEventType::SetRecvHandler: {
         int channel_id = zmq_recv_int32(&event_loop_socket);
-        int progress = zmq_recv_int32(&event_loop_socket);
-        send_complete_handler_(channel_id, progress);
+        MailboxRecvHandlerType* handler = reinterpret_cast<MailboxRecvHandlerType*>(zmq_recv_int64(&event_loop_socket));
+        recv_handlers_[channel_id] = *handler;
         break;
       }
-      case MAILBOX_EVENT_SET_RECV_COMM_HANDLER: {
-        int channel_id = zmq_recv_int32(&event_loop_socket);
-        RecvAvailableHandlerType* handler =
-            reinterpret_cast<RecvAvailableHandlerType*>(zmq_recv_int64(&event_loop_socket));
-        recv_available_handlers_[channel_id] = *handler;
-        break;
-      }
-      case MAILBOX_EVENT_SET_RECV_COMM_COMPLETE_HANDLER: {
-        int channel_id = zmq_recv_int32(&event_loop_socket);
-        RecvCompleteHandlerType* handler =
-            reinterpret_cast<RecvCompleteHandlerType*>(zmq_recv_int64(&event_loop_socket));
-        recv_complete_handlers_[channel_id] = *handler;
-        break;
-      }
-      case MAILBOX_EVENT_SHUTDOWN: {
+      case MailboxEventType::Shutdown: {
         shutdown = true;
         break;
       }
@@ -83,12 +60,11 @@ MailboxEventLoop::MailboxEventLoop(zmq::context_t* zmq_context) : zmq_context_(z
 MailboxEventLoop::~MailboxEventLoop() {
   zmq::socket_t shutdown_sock(*zmq_context_, zmq::socket_type::push);
   shutdown_sock.connect("inproc://mailbox-event-loop");
-  zmq_send_int32(&shutdown_sock, MAILBOX_EVENT_SHUTDOWN);
+  zmq_send_int32(&shutdown_sock, MailboxEventType::Shutdown);
   thread_->join();
 }
 
-void MailboxEventLoop::OnSend(SendHandlerType handler) { send_handler_ = handler; }
-void MailboxEventLoop::OnSendComplete(SendCompleteHandlerType handler) { send_complete_handler_ = handler; }
+void MailboxEventLoop::OnSend(MailboxSendHandlerType handler) { send_handler_ = handler; }
 
 }  // namespace base
 }  // namespace husky


### PR DESCRIPTION
Only Channel communication needs this argument, and so this should be put into the payload instead.