### PR TITLE
[Fix] Fix mailbox and make Shard comparable

### DIFF
--- a/include/husky-base/shard.h
+++ b/include/husky-base/shard.h
@@ -26,7 +26,7 @@ class Shard {
 
   bool operator<(const Shard& shard) const {
     if (process_id_ < shard.GetProcessId() ||
-        (process_id_ == shard.GetProcessId() && local_shard_id_ << shard.GetLocalShardId()))
+        (process_id_ == shard.GetProcessId() && local_shard_id_ < shard.GetLocalShardId()))
       return true;
     return false;
   }

--- a/include/husky-base/shard.h
+++ b/include/husky-base/shard.h
@@ -21,8 +21,15 @@ class Shard {
  public:
   Shard(int local_shard_id, int process_id) : local_shard_id_(local_shard_id), process_id_(process_id) {}
 
-  int GetLocalShardId() { return local_shard_id_; }
-  int GetProcessId() { return process_id_; }
+  int GetLocalShardId() const { return local_shard_id_; }
+  int GetProcessId() const { return process_id_; }
+
+  bool operator<(const Shard& shard) const {
+    if (process_id_ < shard.GetProcessId() ||
+        (process_id_ == shard.GetProcessId() && local_shard_id_ << shard.GetLocalShardId()))
+      return true;
+    return false;
+  }
 
  protected:
   int local_shard_id_;

--- a/src/mailbox_eventloop.cc
+++ b/src/mailbox_eventloop.cc
@@ -34,6 +34,7 @@ MailboxEventLoop::MailboxEventLoop(zmq::context_t* zmq_context) : zmq_context_(z
 
         if (recv_handlers_.find(channel_id) != recv_handlers_.end()) {
           recv_handlers_.at(channel_id)(local_shard_id, bin_stream);
+          delete (bin_stream);
         } else {
           cached_comm_[channel_id].push_back({local_shard_id, bin_stream});
         }
@@ -58,6 +59,7 @@ MailboxEventLoop::MailboxEventLoop(zmq::context_t* zmq_context) : zmq_context_(z
             int local_shard_id = local_shard_id_payload.first;
             BinStream* payload = local_shard_id_payload.second;
             recv_handlers_.at(channel_id)(local_shard_id, payload);
+            delete (payload);
           }
         }
         break;


### PR DESCRIPTION
1. Fix memory leak for mailbox eventloop receiving events.
2. Add `operator<` for Shard so that Shard could be the key type in map